### PR TITLE
Proxy transport

### DIFF
--- a/src/client/ConnectionController/index.ts
+++ b/src/client/ConnectionController/index.ts
@@ -4,6 +4,7 @@ import type * as nt from 'nekoton-wasm';
 import core from '../../core';
 import { GqlSocket, GqlSocketParams } from './gql';
 import { JrpcSocket, JrpcSocketParams } from './jrpc';
+import {ProxyParams} from "./proxy";
 
 export { GqlSocketParams } from './gql';
 export { JrpcSocketParams } from './jrpc';
@@ -272,13 +273,14 @@ export class ConnectionController {
             };
           }
           case "proxy":
+            const connection = params.data.connectionFactory.create(this._clock);
             const transportData: InitializedTransport = {
               id: params.id,
               group,
-              type: 'proxy',
+              type: "proxy",
               data: {
-                connection: params.data,
-                transport: nekoton.Transport.fromProxyConnection(params.data),
+                connection: connection,
+                transport: nekoton.Transport.fromProxyConnection(connection),
               }
             }
             return {
@@ -287,6 +289,8 @@ export class ConnectionController {
             }
         }
       })();
+
+
 
       try {
         if ((await testTransport(transportData, local)) == TestConnectionResult.CANCELLED) {
@@ -357,7 +361,7 @@ function requireInitializedTransport(transport?: InitializedTransport): asserts 
 export type ConnectionData =
   | { id: number; group?: string; type: 'graphql'; data: GqlSocketParams }
   | { id: number; group?: string; type: 'jrpc'; data: JrpcSocketParams }
-  | { id: number; group?: string; type: 'proxy'; data: nt.ProxyConnection };
+  | { id: number; group?: string; type: 'proxy'; data: ProxyParams };
 
 /**
  * @category Client

--- a/src/client/ConnectionController/index.ts
+++ b/src/client/ConnectionController/index.ts
@@ -4,7 +4,7 @@ import type * as nt from 'nekoton-wasm';
 import core from '../../core';
 import { GqlSocket, GqlSocketParams } from './gql';
 import { JrpcSocket, JrpcSocketParams } from './jrpc';
-import {ProxyParams} from "./proxy";
+import { ProxyParams } from './proxy';
 
 export { GqlSocketParams } from './gql';
 export { JrpcSocketParams } from './jrpc';
@@ -228,7 +228,7 @@ export class ConnectionController {
     try {
       const group = params.group != null ? params.group : matchNetworkGroup(params.id);
 
-      const { local, transportData } = await (async() => {
+      const { local, transportData } = await (async () => {
         switch (params.type) {
           case 'graphql': {
             const socket = new GqlSocket();
@@ -272,25 +272,24 @@ export class ConnectionController {
               transportData,
             };
           }
-          case "proxy":
+          case 'proxy': {
             const connection = params.data.connectionFactory.create(this._clock);
             const transportData: InitializedTransport = {
               id: params.id,
               group,
-              type: "proxy",
+              type: 'proxy',
               data: {
                 connection: connection,
                 transport: nekoton.Transport.fromProxyConnection(connection),
-              }
-            }
+              },
+            };
             return {
               local: true,
-              transportData
-            }
+              transportData,
+            };
+          }
         }
       })();
-
-
 
       try {
         if ((await testTransport(transportData, local)) == TestConnectionResult.CANCELLED) {
@@ -369,5 +368,5 @@ export type ConnectionData =
 export type InitializedTransport = { id: number; group: string } & (
   | { type: 'graphql'; data: { socket: GqlSocket; connection: nt.GqlConnection; transport: nt.Transport } }
   | { type: 'jrpc'; data: { socket: JrpcSocket; connection: nt.JrpcConnection; transport: nt.Transport } }
-  | { type: 'proxy'; data: { connection: nt.ProxyConnection, transport: nt.Transport } }
+  | { type: 'proxy'; data: { connection: nt.ProxyConnection; transport: nt.Transport } }
 );

--- a/src/client/ConnectionController/proxy.ts
+++ b/src/client/ConnectionController/proxy.ts
@@ -1,8 +1,7 @@
 import * as nt from 'nekoton-wasm';
 
-
 export abstract class ConnectionFactory {
-  abstract create(clock: nt.ClockWithOffset) : nt.ProxyConnection;
+  abstract create(clock: nt.ClockWithOffset): nt.ProxyConnection;
 }
 /**
  * @category Client

--- a/src/client/ConnectionController/proxy.ts
+++ b/src/client/ConnectionController/proxy.ts
@@ -1,0 +1,12 @@
+import type * as nt from 'nekoton-wasm';
+
+
+export abstract class ConnectionFactory {
+  abstract create(clock: nt.ClockWithOffset) : nt.ProxyConnection;
+}
+/**
+ * @category Client
+ */
+export type ProxyParams = {
+  connectionFactory: ConnectionFactory;
+};

--- a/src/client/ConnectionController/proxy.ts
+++ b/src/client/ConnectionController/proxy.ts
@@ -1,4 +1,4 @@
-import type * as nt from 'nekoton-wasm';
+import * as nt from 'nekoton-wasm';
 
 
 export abstract class ConnectionFactory {

--- a/src/client/SubscriptionController/index.ts
+++ b/src/client/SubscriptionController/index.ts
@@ -16,6 +16,7 @@ export class SubscriptionController {
   private readonly _subscriptionsMutex: Mutex = new Mutex();
   private readonly _sendMessageRequests: Map<string, Map<string, SendMessageCallback>> = new Map();
   private readonly _subscriptionStates: Map<string, SubscriptionState> = new Map();
+  private _pollingInterval: number = DEFAULT_POLLING_INTERVAL;
 
   constructor(
     connectionController: ConnectionController,
@@ -23,6 +24,10 @@ export class SubscriptionController {
   ) {
     this._connectionController = connectionController;
     this._notify = notify;
+  }
+
+  public setPollingInterval(interval: number) {
+    this._pollingInterval = interval;
   }
 
   public async sendMessageLocally(
@@ -237,7 +242,7 @@ export class SubscriptionController {
     const handler = new ContractHandler(address, this);
 
     const subscription = await ContractSubscription.subscribe(this._connectionController, address, handler);
-    subscription.setPollingInterval(DEFAULT_POLLING_INTERVAL);
+    subscription.setPollingInterval(this._pollingInterval);
     handler.enableNotifications();
 
     this._subscriptions.set(address, subscription);

--- a/src/client/SubscriptionController/subscription.ts
+++ b/src/client/SubscriptionController/subscription.ts
@@ -71,6 +71,7 @@ export class ContractSubscription {
 
     this._loopPromise = (async () => {
       const isSimple = !(this._connection instanceof nekoton.GqlConnection);
+      const isProxy = this._connection instanceof nekoton.ProxyConnection;
 
       this._isRunning = true;
       let previousPollingMethod = this._currentPollingMethod;
@@ -86,7 +87,7 @@ export class ContractSubscription {
           debugLog('ContractSubscription -> manual -> waiting begins');
 
           const pollingInterval =
-            this._currentPollingMethod == 'manual' ? this._pollingInterval : INTENSIVE_POLLING_INTERVAL;
+            (this._currentPollingMethod == 'manual' || isProxy) ? this._pollingInterval : INTENSIVE_POLLING_INTERVAL;
 
           await new Promise<void>(resolve => {
             const timerHandle = setTimeout(() => {

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -202,6 +202,13 @@ export class EverscaleStandaloneClient extends SafeEventEmitter implements ever.
     }
   }
 
+  public setPollingInterval = (interval: number) => {
+    if (this._context.connectionController == null || this._context.subscriptionController == null) {
+      throw Error('Connection was not initialized');
+    }
+    this._context.subscriptionController?.setPollingInterval(interval);
+  }
+
   public static setDebugLogger(logger: (...data: any[]) => void) {
     core.debugLog = logger;
   }
@@ -375,18 +382,6 @@ const unsubscribeAll: ProviderHandler<'unsubscribeAll'> = async (ctx, _req) => {
   await ctx.subscriptionController?.unsubscribeFromAllContracts();
   return undefined;
 };
-
-const setPollingInterval: ProviderHandler<'setPollingInterval'> = async (ctx, req) => {
-  requireParams(req);
-  requireConnection(req, ctx);
-
-  const { interval } = req.params;
-  requireNumber(req, req.params, 'interval');
-
-  ctx.subscriptionController?.setPollingInterval(interval);
-
-  return undefined;
-}
 
 const getProviderState: ProviderHandler<'getProviderState'> = async (ctx, _req) => {
   const transport = ctx.connectionController?.initializedTransport;
@@ -970,6 +965,7 @@ const decodeTransaction: ProviderHandler<'decodeTransaction'> = async (_ctx, req
   requireMethodOrArray(req, req.params, 'method');
 
   try {
+    // @ts-ignore
     return nekoton.decodeTransaction(transaction, abi, method) || null;
   } catch (e: any) {
     throw invalidRequest(req, e.toString());
@@ -983,6 +979,7 @@ const decodeTransactionEvents: ProviderHandler<'decodeTransactionEvents'> = asyn
   requireString(req, req.params, 'abi');
 
   try {
+    // @ts-ignore
     return { events: nekoton.decodeTransactionEvents(transaction, abi) };
   } catch (e: any) {
     throw invalidRequest(req, e.toString());

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -376,6 +376,18 @@ const unsubscribeAll: ProviderHandler<'unsubscribeAll'> = async (ctx, _req) => {
   return undefined;
 };
 
+const setPollingInterval: ProviderHandler<'setPollingInterval'> = async (ctx, req) => {
+  requireParams(req);
+  requireConnection(req, ctx);
+
+  const { interval } = req.params;
+  requireNumber(req, req.params, 'interval');
+
+  ctx.subscriptionController?.setPollingInterval(interval);
+
+  return undefined;
+}
+
 const getProviderState: ProviderHandler<'getProviderState'> = async (ctx, _req) => {
   const transport = ctx.connectionController?.initializedTransport;
 

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -9,6 +9,7 @@ import { SubscriptionController } from './SubscriptionController';
 import { Account, AccountsStorage, AccountsStorageContext } from './AccountsStorage';
 import { Keystore } from './keystore';
 import { Clock } from './clock';
+export * from "./ConnectionController/proxy";
 
 export { NETWORK_PRESETS, ConnectionData, ConnectionProperties } from './ConnectionController';
 export { GqlSocketParams, JrpcSocketParams, ConnectionError, checkConnection } from './ConnectionController';

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -9,7 +9,7 @@ import { SubscriptionController } from './SubscriptionController';
 import { Account, AccountsStorage, AccountsStorageContext } from './AccountsStorage';
 import { Keystore } from './keystore';
 import { Clock } from './clock';
-export * from "./ConnectionController/proxy";
+export * from './ConnectionController/proxy';
 
 export { NETWORK_PRESETS, ConnectionData, ConnectionProperties } from './ConnectionController';
 export { GqlSocketParams, JrpcSocketParams, ConnectionError, checkConnection } from './ConnectionController';
@@ -207,7 +207,7 @@ export class EverscaleStandaloneClient extends SafeEventEmitter implements ever.
       throw Error('Connection was not initialized');
     }
     this._context.subscriptionController?.setPollingInterval(interval);
-  }
+  };
 
   public static setDebugLogger(logger: (...data: any[]) => void) {
     core.debugLog = logger;
@@ -584,7 +584,7 @@ const executeLocal: ProviderHandler<'executeLocal'> = async (ctx, req) => {
         timeout,
       ).boc;
     } else {
-      let unsignedMessage = nekoton.createExternalMessage(
+      const unsignedMessage = nekoton.createExternalMessage(
         clock,
         repackedAddress,
         payload.abi,


### PR DESCRIPTION
Added new transport type which allows users to create transport which proxying all requests to some user defined interface-compatible object, so that user can completely control blockchain behavior on his side, hence creating great possibilities for testing and debugging